### PR TITLE
Change DiscoveredCharacteristic API to return long or short UUIDs.

### DIFF
--- a/ble/DiscoveredCharacteristic.h
+++ b/ble/DiscoveredCharacteristic.h
@@ -140,8 +140,8 @@ public:
     }
 
 public:
-    UUID::ShortUUIDBytes_t getShortUUID(void) const {
-        return uuid.getShortUUID();
+    const UUID& getUUID(void) const {
+        return uuid;
     }
 
     const Properties_t& getProperties(void) const {


### PR DESCRIPTION
This second pull request changes the DiscoveredCharacteristic API to have `getUUID()` as opposed to only `getShortUUID()`. Otherwise you can't have long-UUID characteristics... :smile: It needs the corresponding pull request in `nRF51822`.